### PR TITLE
Nova extensão vscode: peacock

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Sinta-se a vontade para adicionar mais extensões. :D
   - [Polacode](https://github.com/acaverna/Extensoes-Maneiras-Para-Sua-IDE/blob/master/vscode.md#polacode)
   - [Thunder Client](https://github.com/acaverna/Extensoes-Maneiras-Para-Sua-IDE/blob/master/vscode.md#thunder-client)
   - [Power Mode](https://marketplace.visualstudio.com/items?itemName=hoovercj.vscode-power-mode)
+  - [Peacock](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock)
 
 - Temas
   - [Caverna Theme](https://github.com/acaverna/Extensoes-Maneiras-Para-Sua-IDE/blob/master/vscode.md#caverna-theme)

--- a/vscode.md
+++ b/vscode.md
@@ -17,6 +17,7 @@
   - [Regex Previewer](https://github.com/acaverna/Extensoes-Maneiras-Para-Sua-IDE/blob/master/vscode.md#regex-previewer)
   - [Thunder Client](https://github.com/acaverna/Extensoes-Maneiras-Para-Sua-IDE/blob/master/vscode.md#thunder-client)
   - [GitHub Copilot](https://copilot.github.com)
+  - [Peacock](https://github.com/acaverna/Extensoes-Maneiras-Para-Sua-IDE/blob/master/vscode.md#peacock)
 
 - Temas
   - [Caverna Theme](https://github.com/acaverna/Extensoes-Maneiras-Para-Sua-IDE/blob/master/vscode.md#caverna-theme)
@@ -110,3 +111,9 @@ Essa extensão permite que você teste as suas expressões regulares utilizando 
 Omni Theme é um tema de Vscode feito pelo pessoal da Rocketseat para toda a comunidade. É um tema principalmente dark. [Acesse aqui.](https://github.com/getomni/visual-studio-code)
 
 ![Omni Theme](https://camo.githubusercontent.com/2d3414ef89c3ac470d279e356288b874f3f180f035213cbf7de88c596cef297e/68747470733a2f2f692e696d6775722e636f6d2f7655514e4558562e706e67)
+
+## Peacock
+
+O Peacock permite a troca de cores do VSCode por workspace. Ideal para quem trabalha com mais de uma janela aberta em projetos diferentes. [Acesse aqui.](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock)
+
+![peacock](https://user-images.githubusercontent.com/24815192/196083608-e16a2ab6-52a1-4fa1-b2ce-658560432dc7.png)


### PR DESCRIPTION
Sugestão de uma nova extensão para a lista do vscode

O Peacock permite a troca de cores do VSCode por workspace. Ideal para quem trabalha com mais de uma janela aberta em projetos diferentes.